### PR TITLE
Update to agenda for meeting 18 October 2021

### DIFF
--- a/meetings/2021/2021-10-18-agenda.md
+++ b/meetings/2021/2021-10-18-agenda.md
@@ -29,6 +29,7 @@ Monday 18 October 2021
 
 The following new pull requests have been received.
 
+- [#148](https://github.com/embench/embench-iot/pull/148) Board config for Freedom E310 Arty FPGA.
 - [#147](https://github.com/embench/embench-iot/pull/147) Use calloc_beebs in md5sum.
 - [#146](https://github.com/embench/embench-iot/pull/146) Fix heap size to be a mutliple of the pointer size in tarfind.
 - [#145](https://github.com/embench/embench-iot/pull/145) Add --benchmark and --exclude options to scripts fore debugging.


### PR DESCRIPTION
Files changed:

	* meetings/2021/2021-10-18-agenda.md: Add link to PR 148 for
	embench-iot.

Signed-off-by: Jeremy Bennett <jeremy.bennett@embecosm.com>