### PR TITLE
Add item to agenda for 15 Nov 2021.

### DIFF
--- a/meetings/2021/2021-11-15-agenda.md
+++ b/meetings/2021/2021-11-15-agenda.md
@@ -61,6 +61,10 @@ There are no new issues raised this month.
 
 A total of 1 issue remains open.
 
+## A compiler benchmark for Embench
+
+Pavel Tikhonov would like to contribute the WD benchmarks for compilers to Embench.  His proposal is described in this [mailing list message](https://lists.librecores.org/pipermail/embench/2021-November/000160.html).
+
 ## Google Summer of Code
 
 Embench is part of the Free and Open Source Silicon Foundation (FOSSi), which in turn is an active participant in the Google Summer of Code, which provides stipends for students and early career engineers to work on open source projects.


### PR DESCRIPTION
Files changed:

	* meetings/2021/2021-11-15-agenda.md: Add agenda item for new
	compiler benchmark.

Signed-off-by: Jeremy Bennett <jeremy.bennett@embecosm.com>